### PR TITLE
[Chore] Update to rocket 0.5 rc.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rocket-authorization"
-version = "0.2.0-rc.2"
+version = "0.2.0-rc.4"
 authors = ["iferc <github@iferc.ca>"]
 edition = "2021"
 description = """
@@ -19,5 +19,5 @@ name = "example"
 path = "./example/src/main.rs"
 
 [dependencies]
-rocket = "0.5.0-rc.2"
+rocket = "0.5.0-rc.4"
 base64 = "~0.13"

--- a/example/src/sysadmin_guard.rs
+++ b/example/src/sysadmin_guard.rs
@@ -11,8 +11,8 @@ impl<'r> FromRequest<'r> for SysAdmin {
     async fn from_request(request: &'r Request<'_>) -> Outcome<Self, Self::Error> {
         let provided_auth = match Credential::<Basic>::from_request(request).await {
             Outcome::Success(auth) => auth,
-            Outcome::Failure(error) => return Outcome::Failure((error.0, ())),
-            Outcome::Forward(_) => return Outcome::Forward(()),
+            Outcome::Error(error) => return Outcome::Error((error.0, ())),
+            Outcome::Forward(status) => return Outcome::Forward(status),
         };
 
         // THIS IS FOR DEMONSTRATION PURPOSES ONLY, THIS IS NOT SECURE USAGE
@@ -24,7 +24,7 @@ impl<'r> FromRequest<'r> for SysAdmin {
         if provided_auth.username == username && provided_auth.password == password {
             Outcome::Success(SysAdmin(username))
         } else {
-            Outcome::Failure((Status::Unauthorized, ()))
+            Outcome::Error((Status::Unauthorized, ()))
         }
     }
 }


### PR DESCRIPTION
Updated the crate to be compatible with `rocket-0.5-rc.4`, released today. This addresses some issues our internal product has, so this is a very selfish PR. :)

I noticed you have branches dedicated to later versions of `rocket-0.5`, so these are based off of your `rocket-0.5-rc.2` branch with breaking changes resolved. I pointed it at that branch even though that's not where I think it will end up. No need to merge this in; feel free to recreate it to follow your pattern.

See https://github.com/SergioBenitez/Rocket/blob/v0.5.0-rc.4/CHANGELOG.md#breaking-changes
And internal PR here https://github.com/WeeverApps/wx-data-services/tree/chore-upgrade-rocket-v0.5.0-rc.4